### PR TITLE
Add API endpoint for user content

### DIFF
--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -1,0 +1,3 @@
+package handlers
+
+// Placeholder for authentication related handlers.

--- a/backend/handlers/purchase_handler.go
+++ b/backend/handlers/purchase_handler.go
@@ -65,3 +65,10 @@ func BuyContent(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Content purchased successfully"})
 }
+
+// GetPurchases returns a list of purchases for the current user.
+// This stub implementation simply returns an empty list until the feature is
+// fully implemented.
+func GetPurchases(c *gin.Context) {
+	c.JSON(http.StatusOK, []models.Purchase{})
+}

--- a/backend/handlers/video.go
+++ b/backend/handlers/video.go
@@ -266,3 +266,26 @@ func DeleteVideo(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Deleted successfully"})
 }
+
+// GetUserVideos returns all posts with media uploaded by the current user
+func GetUserVideos(c *gin.Context) {
+	value, _ := c.Get("user")
+	user, _ := value.(*models.User)
+
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	var posts []models.Post
+	if err := database.DB.Preload("Media").
+		Preload("ModelProfile").
+		Preload("User").
+		Where("user_id = ?", user.ID).
+		Find(&posts).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch content"})
+		return
+	}
+
+	c.JSON(http.StatusOK, posts)
+}

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -1,0 +1,3 @@
+package middleware
+
+// Placeholder middleware for future authentication logic.

--- a/backend/models/post.go
+++ b/backend/models/post.go
@@ -12,6 +12,7 @@ type Post struct {
 	IsPremium   bool      `json:"isPremium"`
 	PublishedAt time.Time `json:"published_time"`
 	LikesCount  int       `json:"likes_count"`
+	Price       float64   `json:"price"`
 
 	UserID       uint         `json:"-"`
 	User         User         `json:"user"`

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -55,6 +55,7 @@ func InitRoutes(r *gin.Engine) {
 	videos := r.Group("/videos", middleware.UserMiddlewareGin())
 	{
 		videos.POST("/upload", handlers.UploadVideo)    // Загрузка видео для поста
+		videos.GET("/user", handlers.GetUserVideos)     // Контент текущего пользователя
 		videos.GET("/:id/stream", handlers.StreamVideo) // Получение ссылки для стрима
 		videos.GET("/:id", handlers.GetMediaByID)       // Получить медиа по ID
 		videos.DELETE("/:id", handlers.DeleteVideo)     // Удалить видео

--- a/backend/services/referral.go
+++ b/backend/services/referral.go
@@ -1,0 +1,9 @@
+package services
+
+import "go-backend/models"
+
+// DistributeReferralBonus is a stub implementation used while the referral
+// system is under development.
+func DistributeReferralBonus(_ models.User, _ float64) {
+	// TODO: implement referral bonus distribution
+}

--- a/backend/utils/referral.go
+++ b/backend/utils/referral.go
@@ -1,0 +1,3 @@
+package utils
+
+// Placeholder utilities for referral system.


### PR DESCRIPTION
## Summary
- add stub files so Go builds
- include Price field in posts
- implement `GetUserVideos` handler and route
- stub out purchases API and referral bonus service

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b2f9283f083269d84bc030479fe7b