### PR TITLE
Add follow and referral support

### DIFF
--- a/backend/database/setup.go
+++ b/backend/database/setup.go
@@ -47,6 +47,8 @@ func MigrateAll() error {
 		&models.Like{},
 		&models.Purchase{},
 		&models.SavedPost{},
+		&models.Follow{},
+		&models.Referral{},
 	)
 	if err != nil {
 		return fmt.Errorf("ошибка миграции: %w", err)

--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"go-backend/models"
+	"go-backend/utils"
 
 	"gorm.io/gorm"
 )
@@ -22,15 +23,25 @@ func GetUserByEmail(email string) (*models.User, error) {
 	return &user, nil
 }
 
-func CreateUser(email string, name string, avatar string) (*models.User, error) {
+func CreateUser(email string, name string, avatar string, refCode string) (*models.User, error) {
 	user := &models.User{
-		Email:     email,
-		Name:      name,
-		AvatarURL: avatar,
-		Nickname:  generateNickname(email),
+		Email:        email,
+		Name:         name,
+		AvatarURL:    avatar,
+		Nickname:     generateNickname(email),
+		ReferralCode: utils.GenerateReferralCode(),
 	}
 	if err := DB.Create(user).Error; err != nil {
 		return nil, err
+	}
+	if refCode != "" {
+		var inviter models.User
+		if err := DB.Where("referral_code = ?", refCode).First(&inviter).Error; err == nil {
+			ref := models.Referral{UserID: inviter.ID, ReferralCode: refCode, InvitedUserID: user.ID}
+			DB.Create(&ref)
+			inviter.Balance += 1
+			DB.Save(&inviter)
+		}
 	}
 	return user, nil
 }

--- a/backend/handlers/follow_handler.go
+++ b/backend/handlers/follow_handler.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"net/http"
+
+	"go-backend/database"
+	"go-backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// FollowUser handles POST /follow/:id to follow another user.
+func FollowUser(c *gin.Context) {
+	val, exists := c.Get("user")
+	if !exists || val == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	user := val.(*models.User)
+
+	targetID := c.Param("id")
+	var target models.User
+	if err := database.DB.First(&target, targetID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	// prevent duplicate follows
+	var f models.Follow
+	if err := database.DB.Where("follower_id = ? AND followed_id = ?", user.ID, target.ID).First(&f).Error; err == nil {
+		c.JSON(http.StatusOK, gin.H{"message": "already following"})
+		return
+	}
+
+	follow := models.Follow{FollowerID: user.ID, FollowedID: target.ID}
+	if err := database.DB.Create(&follow).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "followed"})
+}
+
+// UnfollowUser handles DELETE /follow/:id.
+func UnfollowUser(c *gin.Context) {
+	val, exists := c.Get("user")
+	if !exists || val == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	user := val.(*models.User)
+
+	targetID := c.Param("id")
+	var f models.Follow
+	if err := database.DB.Where("follower_id = ? AND followed_id = ?", user.ID, targetID).First(&f).Error; err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "not following"})
+		return
+	}
+	if err := database.DB.Delete(&f).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "unfollowed"})
+}
+
+// GetFollowers returns the list of followers for the current user.
+func GetFollowers(c *gin.Context) {
+	val, exists := c.Get("user")
+	if !exists || val == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	user := val.(*models.User)
+
+	var followers []models.Follow
+	if err := database.DB.Where("followed_id = ?", user.ID).Find(&followers).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+		return
+	}
+	c.JSON(http.StatusOK, followers)
+}

--- a/backend/handlers/referral_handler.go
+++ b/backend/handlers/referral_handler.go
@@ -1,0 +1,27 @@
+package handlers
+
+import (
+	"net/http"
+
+	"go-backend/database"
+	"go-backend/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetReferrals lists invited users for the authenticated user.
+func GetReferrals(c *gin.Context) {
+	val, exists := c.Get("user")
+	if !exists || val == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	user := val.(*models.User)
+
+	var refs []models.Referral
+	if err := database.DB.Where("user_id = ?", user.ID).Find(&refs).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+		return
+	}
+	c.JSON(http.StatusOK, refs)
+}

--- a/backend/handlers/user_handler.go
+++ b/backend/handlers/user_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"go-backend/database"
 	"go-backend/models"
+	"go-backend/utils"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -39,6 +40,7 @@ func CreateUser(c *gin.Context) {
 		return
 	}
 
+	user.ReferralCode = utils.GenerateReferralCode()
 	if err := database.DB.Create(&user).Error; err != nil {
 		c.Error(err)
 		c.AbortWithStatus(http.StatusInternalServerError)

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -30,11 +30,12 @@ func AuthMiddleware() gin.HandlerFunc {
 		email, _ := decoded.Claims["email"].(string)
 		name, _ := decoded.Claims["name"].(string)
 		avatar, _ := decoded.Claims["picture"].(string)
+		refCode := c.GetHeader("X-Referral-Code")
 
 		user, err := database.GetUserByEmail(email)
 		if err != nil {
 			if err == database.ErrUserNotFound {
-				user, err = database.CreateUser(email, name, avatar)
+				user, err = database.CreateUser(email, name, avatar, refCode)
 				if err != nil {
 					c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to create user"})
 					return

--- a/backend/migrations/000002_referrals.down.sql
+++ b/backend/migrations/000002_referrals.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS referrals;

--- a/backend/migrations/000002_referrals.up.sql
+++ b/backend/migrations/000002_referrals.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE referrals (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    referral_code VARCHAR(50),
+    invited_user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP DEFAULT now()
+);
+CREATE INDEX idx_referrals_user_id ON referrals(user_id);

--- a/backend/models/follow.go
+++ b/backend/models/follow.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+// Follow represents a user's subscription to another user.
+type Follow struct {
+	ID         uint `gorm:"primaryKey"`
+	FollowerID uint
+	FollowedID uint
+	CreatedAt  time.Time
+}

--- a/backend/models/referral.go
+++ b/backend/models/referral.go
@@ -1,0 +1,12 @@
+package models
+
+import "time"
+
+// Referral tracks users invited through a referral code.
+type Referral struct {
+	ID            uint   `gorm:"primaryKey"`
+	UserID        uint   // who invited
+	ReferralCode  string // code used
+	InvitedUserID uint   // new user
+	CreatedAt     time.Time
+}

--- a/backend/models/user.go
+++ b/backend/models/user.go
@@ -1,12 +1,13 @@
 package models
 
 type User struct {
-	ID        uint    `gorm:"primaryKey"`
-	Name      string  `json:"name"`
-	Email     string  `gorm:"unique" json:"email"`
-	Nickname  string  `gorm:"unique" json:"nickname"`
-	Password  string  `json:"-"`
-	Balance   float64 `json:"balance"`
-	AvatarURL string  `json:"avatarUrl"`
-	IsAdmin   bool    `gorm:"default:false" json:"isAdmin"`
+	ID           uint    `gorm:"primaryKey"`
+	Name         string  `json:"name"`
+	Email        string  `gorm:"unique" json:"email"`
+	Nickname     string  `gorm:"unique" json:"nickname"`
+	Password     string  `json:"-"`
+	Balance      float64 `json:"balance"`
+	AvatarURL    string  `json:"avatarUrl"`
+	IsAdmin      bool    `gorm:"default:false" json:"isAdmin"`
+	ReferralCode string  `gorm:"unique" json:"referralCode"`
 }

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -70,6 +70,11 @@ func InitRoutes(r *gin.Engine) {
 		purchases.GET("", handlers.GetPurchases) // История покупок
 	}
 
+	r.POST("/follow/:id", middleware.UserMiddlewareGin(), handlers.FollowUser)
+	r.DELETE("/follow/:id", middleware.UserMiddlewareGin(), handlers.UnfollowUser)
+	r.GET("/followers", middleware.UserMiddlewareGin(), handlers.GetFollowers)
+	r.GET("/referrals", middleware.UserMiddlewareGin(), handlers.GetReferrals)
+
 	// Админские маршруты
 	admin := r.Group("/admin", middleware.UserMiddlewareGin())
 	{


### PR DESCRIPTION
## Summary
- add new Follow and Referral models
- store referral code per user
- create referrals when signing up with a code
- reward inviter with balance
- implement follow/unfollow and referral handlers
- expose new routes
- migrate DB with referrals table

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b529042f883269805ede1d0af5b13