### PR TITLE
Fix failing purchase test

### DIFF
--- a/backend/tests/purchase_handlers_test.go
+++ b/backend/tests/purchase_handlers_test.go
@@ -8,12 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"go-backend/database"
 	"go-backend/models"
 )
 
 func TestPurchaseHandlers(t *testing.T) {
 	r := SetupRouter(t)
-	user := createUser(t, r)
+	var user models.User
+	if err := database.DB.First(&user, 1).Error; err != nil {
+		t.Fatalf("failed to load admin user: %v", err)
+	}
 	user.Balance = 10
 	// update user to set balance
 	body, _ := json.Marshal(user)
@@ -25,7 +29,7 @@ func TestPurchaseHandlers(t *testing.T) {
 		t.Fatalf("update user expected 200, got %d", w.Code)
 	}
 	model := createModel(t, r, user.ID)
-	post := models.Post{Text: "p", UserID: user.ID, ModelID: model.ID, PublishedAt: time.Now()}
+	post := models.Post{Text: "p", UserID: user.ID, ModelID: model.ID, PublishedAt: time.Now(), IsPremium: true, Price: 5}
 	body, _ = json.Marshal(post)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest(http.MethodPost, "/posts", bytes.NewReader(body))


### PR DESCRIPTION
## Summary
- fix failing purchase handler test

## Testing
- `go test ./tests`
- ❌ `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687c70af27b4832690f7ddef2d8aa407